### PR TITLE
Fix sidebar styles

### DIFF
--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -73,11 +73,6 @@
                     <property name="orientation">vertical</property>
                     <property name="width-request">300</property>
 
-                    <style>
-                      <class name="view"/>
-                      <class name="sidebar"/>
-                    </style>
-
                     <child>
                       <object class="AdwHeaderBar" id="sidebar_headerbar">
                         <property name="show-end-title-buttons">false</property>
@@ -151,6 +146,10 @@
                       <object class="EartagSidebar" id="sidebar"/>
                     </child>
                   </object>
+                </child>
+
+                <child type="separator">
+                  <object class="GtkSeparator"/>
                 </child>
 
                 <child type="content">

--- a/src/window.py
+++ b/src/window.py
@@ -31,7 +31,7 @@ from .fileview import EartagFileView
 from .file import EartagFileManager
 from .sidebar import EartagSidebar
 
-from gi.repository import Adw, Gdk, Gio, Gtk, GObject
+from gi.repository import Adw, Gdk, GLib, Gio, Gtk, GObject
 
 @Gtk.Template(resource_path='/app/drey/EarTag/ui/discardwarning.ui')
 class EartagDiscardWarningDialog(Gtk.MessageDialog):
@@ -173,7 +173,12 @@ class EartagWindow(Adw.ApplicationWindow):
         return True
 
     def verify_files_valid(self, drop, task, *args):
-        files = drop.read_value_finish(task).get_files()
+        try:
+            files = drop.read_value_finish(task).get_files()
+        except GLib.GError:
+            self.drop_target.reject()
+            self.on_drag_unhover()
+            return False
         for file in files:
             path = file.get_path()
             if not is_valid_music_file(path):


### PR DESCRIPTION
We don't use .view with sidebars, and while .sidebar provides a separator, it would break when folded.